### PR TITLE
Add more boilerplate comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can run the `generate-subsection` command using `yarn`:
 > yarn generate-subsection {section-name} {path}
 ```
 
-The `path` option should be the path to the directory where you'd like the subsection to be generated (ex. `./src/js/main/`).
+The `path` option should be the path to the directory where you'd like the subsection to be generated (optional, default=`./src/js/main/`).
 
 ## Contribution
 

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function pascalCase (str) {
 function main () {
   const args = process.argv.slice(2)
   const subSectionName = args[0] || 'sub-section'
-  const destination = args[1] || './src'
+  const destination = args[1] || './src/js/main'
   return generate(subSectionName, destination)
 }
 

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   "author": "dpikt",
   "license": "ISC",
   "dependencies": {
-    "dashify": "^0.2.2",
     "fs-extra": "^4.0.2",
     "glob": "^7.1.2",
-    "lodash.camelcase": "^4.3.0"
+    "lodash": "^4.17.11",
+    "pluralize": "^7.0.0"
   },
   "devDependencies": {
     "@launchpadlab/eslint-config": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-subsection-generator",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/template/Routes.js
+++ b/template/Routes.js
@@ -14,8 +14,8 @@ function Routes ({ match: { path } }) {
   return (
     <Layout>
       <Switch>
-        <Route exact path={ path + '/' } component={ Views.%SubSection% } />
-        {/* <Route path={ path + '/:id' } component={ Views.%SubSection%Details } /> */}
+        <Route exact path={ path + '/' } component={ Views.%SubSections% } />
+        <Route path={ path + '/:id' } component={ Views.%SubSection%Show } />
       </Switch>
     </Layout>
   )

--- a/template/Routes.js
+++ b/template/Routes.js
@@ -15,6 +15,7 @@ function Routes ({ match: { path } }) {
     <Layout>
       <Switch>
         <Route exact path={ path + '/' } component={ Views.%SubSection% } />
+        {/* <Route path={ path + '/:id' } component={ Views.%SubSection%Details } /> */}
       </Switch>
     </Layout>
   )

--- a/template/actions.js
+++ b/template/actions.js
@@ -1,1 +1,3 @@
 // import { createAction } from 'redux-actions'
+
+// export const setThing = createAction('SET_THING')

--- a/template/actions.js
+++ b/template/actions.js
@@ -1,3 +1,3 @@
 // import { createAction } from 'redux-actions'
 
-// export const setThing = createAction('SET_THING')
+// export const clear%SubSection% = createAction('CLEAR_%SUB_SECTION%')

--- a/template/reducer.js
+++ b/template/reducer.js
@@ -1,5 +1,5 @@
 import { handleActions } from 'redux-actions'
-// import { selectorForSlice, setState } from 'lp-redux-utils'
+// import { selectorForSlice, unsetState } from 'lp-redux-utils'
 // import { setOnSuccess } from 'lp-redux-api'
 // import * as actions from './actions'
 // import * as apiActions from 'api-actions'
@@ -10,14 +10,16 @@ const reducerKey = '%subSection%'
 const initialState = {}
 
 const reducer = handleActions({
-  // [apiActions.fetchThing]: setOnSuccess('thing'),
-  // [actions.setThing]: setState('thing'),
+  // [apiActions.fetch%SubSections%]: setOnSuccess('%subSections%'),
+  // [apiActions.fetch%SubSection%]: setOnSuccess('%subSection%'),
+  // [actions.clear%SubSection%]: unsetState('%subSection%'),
 }, initialState)
 
 // const select = selectorForSlice(slice)
 
 const selectors = {
-  // thing: select('thing'),
+  // %subSections%: select('%subSections%'),
+  // %subSection%: select('%subSection%'),
 }
 
 export { reducer, selectors, reducerKey }

--- a/template/reducer.js
+++ b/template/reducer.js
@@ -1,15 +1,23 @@
 import { handleActions } from 'redux-actions'
-// import { selectorForSlice } from 'lp-redux-utils'
+// import { selectorForSlice, setState } from 'lp-redux-utils'
+// import { setOnSuccess } from 'lp-redux-api'
+// import * as actions from './actions'
+// import * as apiActions from 'api-actions'
 
 const reducerKey = '%subSection%'
 // const slice = 'root.%subSection%'
 
 const initialState = {}
 
-const reducer = handleActions({}, initialState)
+const reducer = handleActions({
+  // [apiActions.fetchThing]: setOnSuccess('thing'),
+  // [actions.setThing]: setState('thing'),
+}, initialState)
 
 // const select = selectorForSlice(slice)
 
-const selectors = {}
+const selectors = {
+  // thing: select('thing'),
+}
 
 export { reducer, selectors, reducerKey }

--- a/template/views/SubSection.js
+++ b/template/views/SubSection.js
@@ -2,8 +2,15 @@ import React from 'react'
 // import PropTypes from 'prop-types'
 import { compose } from 'recompose'
 import { connect } from 'react-redux'
+// import { onMount, waitFor } from 'lp-hoc'
+// import { selectors } from '../reducer'
+// import * as actions from '../actions'
+// import * as apiActions from 'api-actions'
+// import * as Types from 'types'
 
-const propTypes = {}
+const propTypes = {
+  // thing: Types.thing.isRequired
+}
 
 const defaultProps = {}
 
@@ -18,11 +25,18 @@ function %SubSection% () {
 %SubSection%.defaultProps = defaultProps
 
 function mapStateToProps () {
-  return {}
+  return {
+    // thing: selectors.thing(state)
+  }
 }
 
-const mapDispatchToProps = {}
+const mapDispatchToProps = {
+  // fetchThing: apiActions.fetchThing,
+  // setThing: actions.setThing
+}
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps)
+  connect(mapStateToProps, mapDispatchToProps),
+  // onMount('fetchThing'),
+  // waitFor('thing'),
 )(%SubSection%)

--- a/template/views/SubSectionShow.js
+++ b/template/views/SubSectionShow.js
@@ -2,21 +2,21 @@ import React from 'react'
 // import PropTypes from 'prop-types'
 import { compose } from 'recompose'
 import { connect } from 'react-redux'
-// import { onMount, waitFor } from 'lp-hoc'
+// import { onMount, waitFor, connectParams } from 'lp-hoc'
 // import { selectors } from '../reducer'
 // import * as actions from '../actions'
 // import * as apiActions from 'api-actions'
 // import * as Types from 'types'
 
 const propTypes = {
-  // thing: Types.thing.isRequired
+  // %subSection%: Types.%subSection%.isRequired
 }
 
 const defaultProps = {}
 
 function %SubSection% () {
   return (
-    <div> This is the %SubSection% view! </div>
+    <div> This is the %SubSection% show view! </div>
   )
 }
 
@@ -26,17 +26,24 @@ function %SubSection% () {
 
 function mapStateToProps () {
   return {
-    // thing: selectors.thing(state)
+    // %subSection%: selectors.%subSection%(state)
   }
 }
 
 const mapDispatchToProps = {
-  // fetchThing: apiActions.fetchThing,
-  // setThing: actions.setThing
+  // fetch%SubSection%: apiActions.fetch%SubSection%,
+  // clear%SubSection%: actions.clear%SubSection%
 }
 
+// function onComponentDidMount ({ fetch%SubSection%, id }) {
+//   return fetch%SubSection%(id),
+// }
+
 export default compose(
+  // connectParams('id'),
   connect(mapStateToProps, mapDispatchToProps),
-  // onMount('fetchThing'),
-  // waitFor('thing'),
+  // withProps(modifyProps),
+  // onMount(onComponentDidMount),
+  // waitFor('%subSection%'),
+  // onUnmount('clear%SubSection%'),
 )(%SubSection%)

--- a/template/views/SubSections.js
+++ b/template/views/SubSections.js
@@ -1,0 +1,41 @@
+import React from 'react'
+// import PropTypes from 'prop-types'
+import { compose } from 'recompose'
+import { connect } from 'react-redux'
+// import { onMount, waitFor } from 'lp-hoc'
+// import { selectors } from '../reducer'
+// import * as actions from '../actions'
+// import * as apiActions from 'api-actions'
+// import * as Types from 'types'
+
+const propTypes = {
+  // %subSections%: PropTypes.arrayOf(Types.%subSection%).isRequired,
+}
+
+const defaultProps = {}
+
+function %SubSections% () {
+  return (
+    <div> This is the %SubSection% index view! </div>
+  )
+}
+
+%SubSections%.propTypes = propTypes
+
+%SubSections%.defaultProps = defaultProps
+
+function mapStateToProps () {
+  return {
+    // %subSections%: selectors.%subSections%(state)
+  }
+}
+
+const mapDispatchToProps = {
+  // fetch%SubSections%: apiActions.fetch%SubSections%,
+}
+
+export default compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  // onMount('fetch%SubSections%'),
+  // waitFor('%subSection%'),
+)(%SubSections%)

--- a/yarn.lock
+++ b/yarn.lock
@@ -450,10 +450,6 @@ damerau-levenshtein@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz#03191c432cb6eea168bb77f3a55ffdccb8978514"
 
-dashify@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/dashify/-/dashify-0.2.2.tgz#6a07415a01c91faf4a32e38d9dfba71f61cb20fe"
-
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -1155,10 +1151,6 @@ lodash._topath@^3.0.0:
   dependencies:
     lodash.isarray "^3.0.0"
 
-lodash.camelcase@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
-
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
@@ -1173,6 +1165,11 @@ lodash.get@^3.7.0:
 lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+
+lodash@^4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
@@ -1427,6 +1424,7 @@ pkg-dir@^1.0.0:
 pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
+  integrity sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Should help people get running faster with new subsections, and lower the frustration of writing the same imports again and again.

This PR also updates the default path to the one used in the client template.