### PR TITLE
Update Routes file to move Layout within Route

### DIFF
--- a/ionic-template/Routes.js
+++ b/ionic-template/Routes.js
@@ -11,16 +11,18 @@ function Routes () {
   const { path } = useRouteMatch()
 
   return (
-    <Layout>
-      <IonRouterOutlet>
-        <Route exact path={path}>
+    <IonRouterOutlet>
+      <Route exact path={path}>
+        <Layout>
           <Views.%SubSections% />
-        </Route>
-        <Route path={`${path}/:id`}>
+        </Layout>
+      </Route>
+      <Route path={`${path}/:id`}>
+        <Layout>
           <Views.%SubSection%Show />
-        </Route>
-      </IonRouterOutlet>
-    </Layout>
+        </Layout>
+      </Route>
+    </IonRouterOutlet>
   )
 }
 


### PR DESCRIPTION
### Resolves
- Changes are currently being made in the Ionic Client Template which would affect the new subsection creation. We want to move the `Layout` component within Routes files to make sure that the native iOS swipe back functionality works as expected (with the view sliding animation).
- This is detailed in the https://github.com/LaunchPadLab/ionic-client-template/issues/43 issue and is a follow up to a comment on the Ionic Client Template changes: https://github.com/LaunchPadLab/ionic-client-template/pull/61/files#r1357469568.