### PR TITLE
Support RTK v2 and Redux v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-subsection-generator",
-  "version": "8.0.3",
+  "version": "9.0.0",
   "description": "",
   "main": "index.js",
   "engines": {
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@reduxjs/toolkit": "^2.2.1",
     "react": ">= 16",
-    "react-redux": "^7.2.8 || ^8.0.0 || ^9.1.0",
+    "react-redux": "^8.0.0 || ^9.1.0",
     "react-router-dom": "^4.0.0 || ^5.0.0",
     "redux": "^5.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-subsection-generator",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "",
   "main": "index.js",
   "engines": {
@@ -29,11 +29,11 @@
     "eslint": "^7.32.0"
   },
   "peerDependencies": {
-    "@reduxjs/toolkit": "^1.9.5",
+    "@reduxjs/toolkit": "^2.2.1",
     "react": ">= 16",
-    "react-redux": "^7.2.8 || ^8.0.0",
+    "react-redux": "^7.2.8 || ^8.0.0 || ^9.1.0",
     "react-router-dom": "^4.0.0 || ^5.0.0",
-    "redux": "^4.1.2"
+    "redux": "^5.0.1"
   },
   "optionalDependencies": {
     "@ionic/react": ">= 5"


### PR DESCRIPTION
Add support for latest Redux v5 and Redux Toolkit v2 versions.

Fixes https://github.com/LaunchPadLab/lp-subsection-generator/issues/38.

I linked this project locally to `client-template` and ran the generator without issues. Please let me know if there's any other test I can do.

This is also part of the work on https://github.com/LaunchPadLab/client-template/issues/461.