### PR TITLE
Chore: Remove `defaultProps`

### DIFF
--- a/ionic-template/Layout.jsx
+++ b/ionic-template/Layout.jsx
@@ -5,7 +5,6 @@ import Header from '@/components/Header.jsx'
 const propTypes = {
   children: PropTypes.node.isRequired,
 }
-const defaultProps = {}
 
 // This default layout can be tailored for each page. For example, if a back button is
 // needed in the header for this page, add the "withBackButton" prop to the <Header>
@@ -20,6 +19,5 @@ function Layout({ children }) {
 }
 
 Layout.propTypes = propTypes
-Layout.defaultProps = defaultProps
 
 export default Layout

--- a/ionic-template/Routes.jsx
+++ b/ionic-template/Routes.jsx
@@ -5,7 +5,6 @@ import %SubSection%Show from './views/%SubSection%Show.jsx'
 import Layout from './Layout.jsx'
 
 const propTypes = {}
-const defaultProps = {}
 
 function Routes () {
   const { path } = useRouteMatch()
@@ -25,6 +24,5 @@ function Routes () {
 }
 
 Routes.propTypes = propTypes
-Routes.defaultProps = defaultProps
 
 export default Routes

--- a/ionic-template/views/SubSectionShow.jsx
+++ b/ionic-template/views/SubSectionShow.jsx
@@ -11,7 +11,7 @@ import { IonItem, IonLabel, IonList, IonListHeader } from '@ionic/react'
 const propTypes = {}
 
 function %SubSection%Show () {
-  // const { id } = useParams()
+  const { id } = useParams()
   // const %subSection% = useSelector(selectors.%subSection%)
   // const dispatch = useDispatch()
   // useEffect(() => {

--- a/ionic-template/views/SubSectionShow.jsx
+++ b/ionic-template/views/SubSectionShow.jsx
@@ -9,7 +9,6 @@ import { IonItem, IonLabel, IonList, IonListHeader } from '@ionic/react'
 // import * as apiActions from '@/main/apiActions.js'
 
 const propTypes = {}
-const defaultProps = {}
 
 function %SubSection%Show () {
   // const { id } = useParams()
@@ -50,6 +49,5 @@ function %SubSection%Show () {
 }
 
 %SubSection%Show.propTypes = propTypes
-%SubSection%Show.defaultProps = defaultProps
 
 export default %SubSection%Show

--- a/ionic-template/views/SubSections.jsx
+++ b/ionic-template/views/SubSections.jsx
@@ -8,7 +8,6 @@ import { IonItem, IonLabel, IonList, IonListHeader } from '@ionic/react'
 // import * as apiActions from '@/main/apiActions.js'
 
 const propTypes = {}
-const defaultProps = {}
 
 function %SubSections% () {
   // const %subSections% = useSelector(selectors.%subSections%)
@@ -46,6 +45,5 @@ function %SubSections% () {
 }
 
 %SubSections%.propTypes = propTypes
-%SubSections%.defaultProps = defaultProps
 
 export default %SubSections%

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-subsection-generator",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/template/Layout.jsx
+++ b/template/Layout.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 const propTypes = {
   children: PropTypes.node.isRequired,
 }
-const defaultProps = {}
 
 function Layout ({ children }) {
   return (
@@ -14,6 +13,5 @@ function Layout ({ children }) {
 }
 
 Layout.propTypes = propTypes
-Layout.defaultProps = defaultProps
 
 export default Layout

--- a/template/Routes.jsx
+++ b/template/Routes.jsx
@@ -5,7 +5,6 @@ import %SubSection%Show from './views/%SubSection%Show.jsx'
 import Layout from './Layout.jsx'
 
 const propTypes = {}
-const defaultProps = {}
 
 function Routes () {
   const { path } = useRouteMatch()
@@ -25,6 +24,5 @@ function Routes () {
 }
 
 Routes.propTypes = propTypes
-Routes.defaultProps = defaultProps
 
 export default Routes

--- a/template/views/SubSectionShow.jsx
+++ b/template/views/SubSectionShow.jsx
@@ -8,7 +8,6 @@
 // import * as apiActions from '@/main/apiActions.js'
 
 const propTypes = {}
-const defaultProps = {}
 
 function %SubSection%Show () {
   // const { id } = useParams()
@@ -29,6 +28,5 @@ function %SubSection%Show () {
 }
 
 %SubSection%Show.propTypes = propTypes
-%SubSection%Show.defaultProps = defaultProps
 
 export default %SubSection%Show

--- a/template/views/SubSections.jsx
+++ b/template/views/SubSections.jsx
@@ -7,7 +7,6 @@
 // import * as apiActions from '@/main/apiActions.js'
 
 const propTypes = {}
-const defaultProps = {}
 
 function %SubSections% () {
   // const dispatch = useDispatch()
@@ -23,6 +22,5 @@ function %SubSections% () {
 }
 
 %SubSections%.propTypes = propTypes
-%SubSections%.defaultProps = defaultProps
 
 export default %SubSections%


### PR DESCRIPTION
React ^18 is issuing warnings about a future deprecation of `defaultProps` declaration. Such declarations will be removed from all newly-generated subsections.

This feature can be tested by performing the following command in a cloned copy of this repo, which the `chore/remove-default-props` branch checked out:
```bash
$ yarn link
```
Then, in a version of the client or ionic-client template-based repos, run the following command:
```bash
$ yarn link "@launchpadlab/lp-subsection-generator"
```
Then, generate a new subsection in the client or ionic-client-based repo. For example:
```bash
$ yarn generate-subsection accounts
```