### PR TITLE
Updates to Accommodate React Router 6

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+"@launchpadlab/prettier-config"

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,15 +1,24 @@
 # Migration Guide
 
 ## Migration to Version ^7.0.0
+
 Version 7 of the lp-subsection-generator introduced the following changes that may break existing usage of this command:
+
 1. Version 7 of the lp-subsection-generator requires that a Node version >= Node 12 be installed.
 1. The lp-subsection-generator argument `subsection-name` is now required. Previously, this argument was optional and would default to `sub-section`.
 
 ## Migration to Version ^8.0.0
+
 Version 8 requires `@reduxjs/toolkit`, which is now standard across LPL's client templates.
 
 ## Migration to Version ^9.0.0
+
 Version 9 requires major upgrades for two peer dependencies: `@reduxjs/toolkit@^2.2.1` and `redux@^5.0.1`. Refer to the [Migrating to RTK 2.0 and Redux 5.0 documentation](https://redux-toolkit.js.org/usage/migrating-rtk-2) for more details.
 
 ## Migration to Version ^10.0.0
+
 Version 10 supports the Vite-based version of the [client-template](https://github.com/LaunchPadLab/client-template) and the [ionic-client-template](https://github.com/LaunchPadLab/ionic-client-template). If you plan on using this version, ensure that you're using at least `v14` of the client-template or `v8` of the ionic-client-template.
+
+## Migration to Version ^11.0.0
+
+Version 11 supports the React Router v6 version of the [client-template](https://github.com/LaunchPadLab/client-template). If you plan on using this version, be aware that routing in React Router v6 is significantly different than earlier React Router versions. See the [React Router v6 documentation](https://reactrouter.com/6.30.0) for more information.

--- a/generate.js
+++ b/generate.js
@@ -6,67 +6,99 @@ const pluralize = require('pluralize')
 const { camelCase, kebabCase, flow, snakeCase, toUpper } = require('lodash')
 const screamingSnakeCase = flow(snakeCase, toUpper)
 
-function generate (subSectionName, destination, options) {
-  // Compute all casings
-  const singularName = pluralize.singular(subSectionName)
-  const camelCaseName = camelCase(singularName)
-  const kebabCaseName = kebabCase(singularName)
-  const pascalCaseName = pascalCase(singularName)
-  const screamingSnakeCaseName = screamingSnakeCase(singularName)
-  // Compute paths
-  const packagePath = getPackagePath()
-  const root = process.cwd()
-  const templatePath = templatePathFromTemplateType(options)
-  // GENERATE
-  console.log('Generating...')
-  // Copy files over
-  fs.copySync(path.resolve(packagePath, templatePath), path.resolve(packagePath, `./${ subSectionName }`))
-  // Replace template variables in files
-  const allFiles = glob.sync(path.resolve(packagePath, `./${ subSectionName }/**/*.{js,jsx}`))
-  allFiles.forEach(file => {
-    const template = fs.readFileSync(file, 'utf8')
-    const result = template
-      .replace(/%subsection%/g, subSectionName)
-      .replace(/%sub-section%/g, kebabCaseName)
-      .replace(/%subSection%/g, camelCaseName)
-      .replace(/%SubSection%/g, pascalCaseName)
-      .replace(/%SUB_SECTION%/g, screamingSnakeCaseName)
-      .replace(/%sub-sections%/g, pluralize(kebabCaseName))
-      .replace(/%subSections%/g, pluralize(camelCaseName))
-      .replace(/%SubSections%/g, pluralize(pascalCaseName))
-      .replace(/%SUB_SECTIONS%/g, pluralize(screamingSnakeCaseName))
-    return fs.writeFileSync(file, result)
-  })
-  // Rename view files
-  fs.renameSync(path.resolve(packagePath, `./${ subSectionName }/views/SubSections.jsx`), path.resolve(packagePath, `./${ subSectionName }/views/${ pluralize(pascalCaseName) }.jsx`))
-  fs.renameSync(path.resolve(packagePath, `./${ subSectionName }/views/SubSectionShow.jsx`), path.resolve(packagePath, `./${ subSectionName }/views/${ pascalCaseName }Show.jsx`))
-  // Move to final dest
-  fs.moveSync(path.resolve(packagePath, `./${ subSectionName }`), path.resolve(root, destination, subSectionName))
-  console.log('Done!')
+function generate(subSectionName, destination, options) {
+	// Compute all casings
+	const singularName = pluralize.singular(subSectionName)
+	const camelCaseName = camelCase(singularName)
+	const kebabCaseName = kebabCase(singularName)
+	const pascalCaseName = pascalCase(singularName)
+	const screamingSnakeCaseName = screamingSnakeCase(singularName)
+	// Compute paths
+	const packagePath = getPackagePath()
+	const root = process.cwd()
+	const templatePath = templatePathFromTemplateType(options)
+	// GENERATE
+	console.log('Generating...')
+	// Copy files over
+	fs.copySync(
+		path.resolve(packagePath, templatePath),
+		path.resolve(packagePath, `./${subSectionName}`)
+	)
+	// Replace template variables in files
+	const allFiles = glob.sync(
+		path.resolve(packagePath, `./${subSectionName}/**/*.{js,jsx}`)
+	)
+	allFiles.forEach((file) => {
+		const template = fs.readFileSync(file, 'utf8')
+		const result = template
+			.replace(/%subsection%/g, subSectionName)
+			.replace(/%sub-section%/g, kebabCaseName)
+			.replace(/%subSection%/g, camelCaseName)
+			.replace(/%SubSection%/g, pascalCaseName)
+			.replace(/%SUB_SECTION%/g, screamingSnakeCaseName)
+			.replace(/%sub-sections%/g, pluralize(kebabCaseName))
+			.replace(/%subSections%/g, pluralize(camelCaseName))
+			.replace(/%SubSections%/g, pluralize(pascalCaseName))
+			.replace(/%SUB_SECTIONS%/g, pluralize(screamingSnakeCaseName))
+		return fs.writeFileSync(file, result)
+	})
+	// Rename view files
+	fs.renameSync(
+		path.resolve(packagePath, `./${subSectionName}/views/SubSections.jsx`),
+		path.resolve(
+			packagePath,
+			`./${subSectionName}/views/${pluralize(pascalCaseName)}.jsx`
+		)
+	)
+	fs.renameSync(
+		path.resolve(packagePath, `./${subSectionName}/views/SubSectionShow.jsx`),
+		path.resolve(
+			packagePath,
+			`./${subSectionName}/views/${pascalCaseName}Show.jsx`
+		)
+	)
+	// Rename routes file
+	fs.renameSync(
+		path.resolve(packagePath, `./${subSectionName}/Routes.jsx`),
+		path.resolve(packagePath, `./${subSectionName}/${pascalCaseName}Routes.jsx`)
+	)
+	// Move to final dest
+	fs.moveSync(
+		path.resolve(packagePath, `./${subSectionName}`),
+		path.resolve(root, destination, subSectionName)
+	)
+	console.log('Done!')
 }
 
 module.exports = generate
 
-function getPackagePath () {
-  try {
-    return path.resolve(require.resolve('@launchpadlab/lp-subsection-generator'), '../')
-  } catch (e) {
-    console.log('Path not found, running locally')
-    return __dirname
-  }
+function getPackagePath() {
+	try {
+		return path.resolve(
+			require.resolve('@launchpadlab/lp-subsection-generator'),
+			'../'
+		)
+	} catch (e) {
+		console.log('Path not found, running locally')
+		return __dirname
+	}
 }
 
-function pascalCase (str) {
-  const cased = camelCase(str)
-  return cased.charAt(0).toUpperCase() + cased.slice(1)
+function pascalCase(str) {
+	const cased = camelCase(str)
+	return cased.charAt(0).toUpperCase() + cased.slice(1)
 }
 
 function templatePathFromTemplateType(templateType) {
-  switch(templateType) {
-    case "client": return './template'
-    case "ionic": return './ionic-template'
+	switch (templateType) {
+		case 'client':
+			return './template'
+		case 'ionic':
+			return './ionic-template'
 
-    default:
-      throw new Error (`generate-subsection: [ERROR]: unknown template type [${templateType}]`)
-  }
+		default:
+			throw new Error(
+				`generate-subsection: [ERROR]: unknown template type [${templateType}]`
+			)
+	}
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@launchpadlab/eslint-config": "^2.1.0",
+    "@launchpadlab/prettier-config": "^2.0.1",
     "eslint": "^7.32.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-subsection-generator",
-  "version": "10.1.0",
+  "version": "11.0.0",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/template/Layout.jsx
+++ b/template/Layout.jsx
@@ -1,15 +1,9 @@
-import PropTypes from 'prop-types'
+import { Outlet } from 'react-router-dom'
 
-const propTypes = {
-  children: PropTypes.node.isRequired,
-}
+const propTypes = {}
 
-function Layout ({ children }) {
-  return (
-    <div>
-      { children }
-    </div>
-  )
+function Layout() {
+	return <Outlet />
 }
 
 Layout.propTypes = propTypes

--- a/template/Routes.jsx
+++ b/template/Routes.jsx
@@ -2,7 +2,7 @@
 import { Navigate, Route, Routes } from 'react-router-dom'
 
 import %SubSections% from './views/%SubSections%.jsx'
-import % SubSection % Show from './views/%SubSection%Show.jsx'
+import %SubSection%Show from './views/%SubSection%Show.jsx'
 
 import Layout from './Layout.jsx'
 
@@ -12,8 +12,8 @@ function Routes () {
   return (
     <Routes>
       <Route element={<Layout />}>
-        <Route index element={<% SubSections % />} />
-        <Route path="/:id" element={<% SubSection % Show />} />
+        <Route index element={<%SubSections% />} />
+        <Route path="/:id" element={<%SubSection%Show />} />
         <Route path="*" element={<Navigate to=".." replace />} />
       </Route>
     </Routes>

--- a/template/Routes.jsx
+++ b/template/Routes.jsx
@@ -1,25 +1,22 @@
 // import PropTypes from 'prop-types'
-import { Route, Switch, useRouteMatch } from 'react-router-dom'
+import { Navigate, Route, Routes } from 'react-router-dom'
+
 import %SubSections% from './views/%SubSections%.jsx'
-import %SubSection%Show from './views/%SubSection%Show.jsx'
+import % SubSection % Show from './views/%SubSection%Show.jsx'
+
 import Layout from './Layout.jsx'
 
 const propTypes = {}
 
 function Routes () {
-  const { path } = useRouteMatch()
-
   return (
-    <Layout>
-      <Switch>
-        <Route exact path={path}>
-          <%SubSections% />
-        </Route>
-        <Route path={`${path}/:id`}>
-          <%SubSection%Show />
-        </Route>
-      </Switch>
-    </Layout>
+    <Routes>
+      <Route element={<Layout />}>
+        <Route index element={<% SubSections % />} />
+        <Route path="/:id" element={<% SubSection % Show />} />
+        <Route path="*" element={<Navigate to=".." replace />} />
+      </Route>
+    </Routes>
   )
 }
 

--- a/template/Routes.jsx
+++ b/template/Routes.jsx
@@ -8,7 +8,7 @@ import Layout from './Layout.jsx'
 
 const propTypes = {}
 
-function Routes () {
+function %SubSection%Routes () {
   return (
     <Routes>
       <Route element={<Layout />}>
@@ -20,6 +20,6 @@ function Routes () {
   )
 }
 
-Routes.propTypes = propTypes
+%SubSection%Routes.propTypes = propTypes
 
-export default Routes
+export default %SubSection%Routes

--- a/yarn.lock
+++ b/yarn.lock
@@ -165,6 +165,11 @@
     eslint-plugin-import "^2.13.0"
     eslint-plugin-react "^7.10.0"
 
+"@launchpadlab/prettier-config@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@launchpadlab/prettier-config/-/prettier-config-2.0.1.tgz#0f2a5b9617f5518f228cf6251c2aa0835bfbe174"
+  integrity sha512-sbTYdNV818VvhpxTObq0Ga6w0bZTgTSh4pIhRLx6ZQkOa57VFV2Doa/bxBzI+JsVCqG42HrJUNMv/c6wN578aw==
+
 "@stencil/core@^2.18.0":
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.20.0.tgz#0e68b5b42e727233803291eb0367ab2b53f7f1f3"


### PR DESCRIPTION
Updates the client template subsection generator to accommodate React Router 6. See https://github.com/LaunchPadLab/client-template/pull/485 for the client changes that prompted this update.

To test this:
1. Pull down the latest from this repository and switch to the `feat/react-router-6` branch.
2. Execute `yarn link` in the root of this project
3. Navigate to a local copy of the `client-template` repository and pull the latest from the `main` branch.
4. Execute `yarn link "@launchpadlab/lp-subsection-generator"` to use the local subsection generator
5. Generate a subsection. For example, to generate the `accounts` subsection execute `yarn generate-subsection accounts` in the client-template project root folder.
6. Integrate the accounts subsection into the main `<AppRouter>` component.
7. Start the client template and verify that:
  a. You can navigate to the new `accounts` subsection, i.e., `http://localhost:8080/accounts`
  b. That the accounts index view is displayed
  c. You can navigate to the a specific account, i.e., `http://localhost:8080/accounts/3`
  d. That the accounts show view is displayed.
8. Verify that navigating back to the `/home` route is still functional.
9. Verify that navigating to the `/styleguide` is still functional.